### PR TITLE
Update idr0021 roi notebook

### DIFF
--- a/notebooks/idr0021_rois.ipynb
+++ b/notebooks/idr0021_rois.ipynb
@@ -51,16 +51,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Find the project and table file\n",
-    "projectName <- 'idr0021'\n",
+    "# Project with the 'Summary_from_Fiji' table attached\n",
+    "projectId <- 872\n",
     "tableName <- 'Summary_from_Fiji'\n",
     "\n",
-    "searchResult <- searchFor(server, Project, 'Name', projectName)\n",
-    "project <- searchResult[[1]]\n",
+    "project <- loadObject(server, \"ProjectData\", projectId)\n",
     "\n",
-    "annos <- getAnnotations(server, 'ProjectData', getOMEROID(project), nameFilter = tableName)\n",
+    "annos <- getAnnotations(server, 'ProjectData', projectId, nameFilter = tableName)\n",
     "annotationFileID = as.integer(annos$FileID)\n",
-    "\n",
     "\n",
     "# Load the table (column 14 and 15, Dataset and bouding_box) directly as R dataframe\n",
     "df <- loadDataframe(project, annotationFileID, columns=c(14, 15))\n",
@@ -89,7 +87,8 @@
     "\n",
     "\n",
     "# Use the bounding box of the biggest shapes for the specified channel\n",
-    "df$diameter <- sqrt(df$Bounding_Box)"
+    "df$diameter <- sqrt(df$Bounding_Box)\n",
+    "df"
    ]
   },
   {


### PR DESCRIPTION
Remove the 'search' for the project part. Can't assume that there is only one idr0021 project, which has exactly the right annotation attached. Instead the user has to paste the ID of the project.

Unfortunately I can't  test it any longer now, building it locally with `repo2docker` but then it can't load the R kernel. Strangely it works outside this PR.