### PR TITLE
Bump rgateway to 0.4.11 and R 4.1.3

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,22 +3,21 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- bioconductor-ebimage
-- bioconductor-biocgenerics
+- bioconductor-ebimage=4.36.0
+- bioconductor-biocgenerics=0.40.0
 - openjdk=11
-- r-assertthat
+- r-assertthat=0.2.1
 # https://github.com/ContinuumIO/anaconda-issues/issues/4656
 - r-base=4.1.3
-- r-devtools
-- r-httr
-- r-irdisplay
-- r-irkernel
-- r-jpeg
-- r-repr
-- r-rjava
-- r-roxygen2
-- r-testthat
-- r-tidyverse
-- r-xml2
-- r-getpass
-
+- r-devtools=2.4.3
+- r-httr=1.4.3
+- r-irdisplay=1.1
+- r-irkernel=1.2
+- r-jpeg=0.1
+- r-repr=1.1.4
+- r-rjava=1.0
+- r-roxygen2=7.2.0
+- r-testthat=3.1.4
+- r-tidyverse=1.3.1
+- r-xml2=1.3.3
+- r-getpass=0.2

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,20 +3,22 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- bioconductor-ebimage=4.24
+- bioconductor-ebimage
+- bioconductor-biocgenerics
 - openjdk=11
-- r-assertthat=0.2
+- r-assertthat
 # https://github.com/ContinuumIO/anaconda-issues/issues/4656
-- r-base=3.5
-- r-devtools=2.2
-- r-httr=1.4
-- r-irdisplay=0.7
-- r-irkernel=1.0
-- r-jpeg=0.1_8
-- r-repr=1.1
-- r-rjava=0.9
-- r-roxygen2=7.0
-- r-testthat=2.1
-- r-tidyverse=1.3
-- r-xml2=1.2
-- r-getpass=0.2
+- r-base=4.1.3
+- r-devtools
+- r-httr
+- r-irdisplay
+- r-irkernel
+- r-jpeg
+- r-repr
+- r-rjava
+- r-roxygen2
+- r-testthat
+- r-tidyverse
+- r-xml2
+- r-getpass
+

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-ROMERO_VERSION=v0.4.9
+ROMERO_VERSION=v0.4.11
 curl -sf https://raw.githubusercontent.com/ome/rOMERO-gateway/$ROMERO_VERSION/install.R --output install.R
 OMERO_LIBS_DOWNLOAD=TRUE Rscript install.R --version=$ROMERO_VERSION --quiet
 rm install.R 


### PR DESCRIPTION
Bump rgateway to the latest version 0.4.11 and R to the latest on conda available version 4.1.3 . Also removes all the version pins for the dependant `r-*` packages, otherwise you have to manually resolve all the version dependencies.
